### PR TITLE
add in .gitignore pyvenv and PyCharm files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,12 @@
 htmlcov
 .DS_Store
 venv
+pyvenv
 distribute_setup.py
 distribute-*.tar.gz
 build
 dist
 *.egg-info
 .tox
+.idea/
+*.iml


### PR DESCRIPTION
Hi,

Is it should be possible to integrate this pull request ?
Without this commit, I've this in `git status`:

    lg@steroids:~/Documents/IDEA/tulip$ git status
    On branch master
    Your branch is up-to-date with 'origin/master'.

    Untracked files:
    (use "git add <file>..." to include in what will be committed)

            .idea/
            pyvenv/
            tulip.iml

    nothing added to commit but untracked files present (use "git add" to track)