### PR TITLE
Rename asyncio.async to asyncio.create_task

### DIFF
--- a/asyncio/base_events.py
+++ b/asyncio/base_events.py
@@ -293,7 +293,7 @@ class BaseEventLoop(events.AbstractEventLoop):
         self._check_closed()
 
         new_task = not isinstance(future, futures.Future)
-        future = tasks.async(future, loop=self)
+        future = tasks.create_task(future, loop=self)
         if new_task:
             # An exception is raised if the future didn't complete, so there
             # is no need to log the "destroy pending task" message

--- a/asyncio/windows_events.py
+++ b/asyncio/windows_events.py
@@ -488,7 +488,7 @@ class IocpProactor:
 
         future = self._register(ov, listener, finish_accept)
         coro = accept_coro(future, conn)
-        tasks.async(coro, loop=self._loop)
+        tasks.create_task(coro, loop=self._loop)
         return future
 
     def connect(self, conn, address):

--- a/examples/stacks.py
+++ b/examples/stacks.py
@@ -18,7 +18,7 @@ def doit():
     l = get_event_loop()
     lr = l.run_until_complete
     r, w = lr(open_connection('python.org', 80))
-    t1 = async(helper(r))
+    t1 = create_task(helper(r))
     for t in Task.all_tasks(): t.print_stack()
     print('---')
     l._run_once()

--- a/tests/test_base_events.py
+++ b/tests/test_base_events.py
@@ -499,7 +499,7 @@ class BaseEventLoopTests(test_utils.TestCase):
 
         # Test Future.__del__
         with mock.patch('asyncio.base_events.logger') as log:
-            fut = asyncio.async(zero_error_coro(), loop=self.loop)
+            fut = asyncio.create_task(zero_error_coro(), loop=self.loop)
             fut.add_done_callback(lambda *args: self.loop.stop())
             self.loop.run_forever()
             fut = None # Trigger Future.__del__ or futures._TracebackLogger
@@ -662,7 +662,7 @@ class BaseEventLoopTests(test_utils.TestCase):
         self.set_event_loop(loop)
 
         coro = test()
-        task = asyncio.async(coro, loop=loop)
+        task = asyncio.create_task(coro, loop=loop)
         self.assertIsInstance(task, MyTask)
 
         # make warnings quiet
@@ -1224,7 +1224,7 @@ class BaseEventLoopWithSelectorTests(test_utils.TestCase):
                          "took .* seconds$")
 
         # slow task
-        asyncio.async(stop_loop_coro(self.loop), loop=self.loop)
+        asyncio.create_task(stop_loop_coro(self.loop), loop=self.loop)
         self.loop.run_forever()
         fmt, *args = m_logger.warning.call_args[0]
         self.assertRegex(fmt % tuple(args),

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -76,7 +76,7 @@ class TaskTests(test_utils.TestCase):
         @asyncio.coroutine
         def notmuch():
             return 'ok'
-        t = asyncio.async(notmuch(), loop=self.loop)
+        t = asyncio.create_task(notmuch(), loop=self.loop)
         self.loop.run_until_complete(t)
         self.assertTrue(t.done())
         self.assertEqual(t.result(), 'ok')
@@ -84,7 +84,7 @@ class TaskTests(test_utils.TestCase):
 
         loop = asyncio.new_event_loop()
         self.set_event_loop(loop)
-        t = asyncio.async(notmuch(), loop=loop)
+        t = asyncio.create_task(notmuch(), loop=loop)
         self.assertIs(t._loop, loop)
         loop.run_until_complete(t)
         loop.close()
@@ -93,7 +93,7 @@ class TaskTests(test_utils.TestCase):
         f_orig = asyncio.Future(loop=self.loop)
         f_orig.set_result('ko')
 
-        f = asyncio.async(f_orig)
+        f = asyncio.create_task(f_orig)
         self.loop.run_until_complete(f)
         self.assertTrue(f.done())
         self.assertEqual(f.result(), 'ko')
@@ -103,11 +103,11 @@ class TaskTests(test_utils.TestCase):
         self.set_event_loop(loop)
 
         with self.assertRaises(ValueError):
-            f = asyncio.async(f_orig, loop=loop)
+            f = asyncio.create_task(f_orig, loop=loop)
 
         loop.close()
 
-        f = asyncio.async(f_orig, loop=self.loop)
+        f = asyncio.create_task(f_orig, loop=self.loop)
         self.assertIs(f, f_orig)
 
     def test_async_task(self):
@@ -115,7 +115,7 @@ class TaskTests(test_utils.TestCase):
         def notmuch():
             return 'ok'
         t_orig = asyncio.Task(notmuch(), loop=self.loop)
-        t = asyncio.async(t_orig)
+        t = asyncio.create_task(t_orig)
         self.loop.run_until_complete(t)
         self.assertTrue(t.done())
         self.assertEqual(t.result(), 'ok')
@@ -125,16 +125,16 @@ class TaskTests(test_utils.TestCase):
         self.set_event_loop(loop)
 
         with self.assertRaises(ValueError):
-            t = asyncio.async(t_orig, loop=loop)
+            t = asyncio.create_task(t_orig, loop=loop)
 
         loop.close()
 
-        t = asyncio.async(t_orig, loop=self.loop)
+        t = asyncio.create_task(t_orig, loop=self.loop)
         self.assertIs(t, t_orig)
 
     def test_async_neither(self):
         with self.assertRaises(TypeError):
-            asyncio.async('ok')
+            asyncio.create_task('ok')
 
     def test_task_repr(self):
         self.loop.set_debug(False)
@@ -1377,7 +1377,7 @@ class TaskTests(test_utils.TestCase):
             else:
                 proof += 10
 
-        f = asyncio.async(outer(), loop=self.loop)
+        f = asyncio.create_task(outer(), loop=self.loop)
         test_utils.run_briefly(self.loop)
         f.cancel()
         self.loop.run_until_complete(f)
@@ -1402,7 +1402,7 @@ class TaskTests(test_utils.TestCase):
             d, p = yield from asyncio.wait([inner()], loop=self.loop)
             proof += 100
 
-        f = asyncio.async(outer(), loop=self.loop)
+        f = asyncio.create_task(outer(), loop=self.loop)
         test_utils.run_briefly(self.loop)
         f.cancel()
         self.assertRaises(
@@ -1458,7 +1458,7 @@ class TaskTests(test_utils.TestCase):
             yield from asyncio.shield(inner(), loop=self.loop)
             proof += 100
 
-        f = asyncio.async(outer(), loop=self.loop)
+        f = asyncio.create_task(outer(), loop=self.loop)
         test_utils.run_briefly(self.loop)
         f.cancel()
         with self.assertRaises(asyncio.CancelledError):
@@ -1636,7 +1636,7 @@ class TaskTests(test_utils.TestCase):
 
         # schedule the task
         coro = kill_me(self.loop)
-        task = asyncio.async(coro, loop=self.loop)
+        task = asyncio.create_task(coro, loop=self.loop)
         self.assertEqual(asyncio.Task.all_tasks(loop=self.loop), {task})
 
         # execute the task so it waits for future
@@ -1968,8 +1968,8 @@ class CoroutineGatherTests(GatherTestsBase, test_utils.TestCase):
             yield from waiter
             proof += 1
 
-        child1 = asyncio.async(inner(), loop=self.one_loop)
-        child2 = asyncio.async(inner(), loop=self.one_loop)
+        child1 = asyncio.create_task(inner(), loop=self.one_loop)
+        child2 = asyncio.create_task(inner(), loop=self.one_loop)
         gatherer = None
 
         @asyncio.coroutine
@@ -1979,7 +1979,7 @@ class CoroutineGatherTests(GatherTestsBase, test_utils.TestCase):
             yield from gatherer
             proof += 100
 
-        f = asyncio.async(outer(), loop=self.one_loop)
+        f = asyncio.create_task(outer(), loop=self.one_loop)
         test_utils.run_briefly(self.one_loop)
         self.assertTrue(f.cancel())
         with self.assertRaises(asyncio.CancelledError):
@@ -2006,7 +2006,7 @@ class CoroutineGatherTests(GatherTestsBase, test_utils.TestCase):
         def outer():
             yield from asyncio.gather(inner(a), inner(b), loop=self.one_loop)
 
-        f = asyncio.async(outer(), loop=self.one_loop)
+        f = asyncio.create_task(outer(), loop=self.one_loop)
         test_utils.run_briefly(self.one_loop)
         a.set_result(None)
         test_utils.run_briefly(self.one_loop)

--- a/tests/test_windows_events.py
+++ b/tests/test_windows_events.py
@@ -37,7 +37,7 @@ class ProactorTests(test_utils.TestCase):
     def test_close(self):
         a, b = self.loop._socketpair()
         trans = self.loop._make_socket_transport(a, asyncio.Protocol())
-        f = asyncio.async(self.loop.sock_recv(b, 100))
+        f = asyncio.create_task(self.loop.sock_recv(b, 100))
         trans.close()
         self.loop.run_until_complete(f)
         self.assertEqual(f.result(), b'')


### PR DESCRIPTION
Since we're considering adding async/await to python at some point, I think we should rename 'async' function to 'create_task', since it does essentially the same thing.

asyncio has a provisional status in standard library, so while this is a breaking change we can do it.